### PR TITLE
Backport of OpenWRT r43084

### DIFF
--- a/package/busybox/Makefile
+++ b/package/busybox/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=busybox
 PKG_VERSION:=1.19.4
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 PKG_FLAGS:=essential
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2

--- a/package/busybox/patches/270-libbb_make_unicode_printable.patch
+++ b/package/busybox/patches/270-libbb_make_unicode_printable.patch
@@ -1,0 +1,20 @@
+--- a/libbb/printable_string.c
++++ b/libbb/printable_string.c
+@@ -31,8 +31,6 @@ const char* FAST_FUNC printable_string(u
+ 		}
+ 		if (c < ' ')
+ 			break;
+-		if (c >= 0x7f)
+-			break;
+ 		s++;
+ 	}
+ 
+@@ -45,7 +43,7 @@ const char* FAST_FUNC printable_string(u
+ 			unsigned char c = *d;
+ 			if (c == '\0')
+ 				break;
+-			if (c < ' ' || c >= 0x7f)
++			if (c < ' ')
+ 				*d = '?';
+ 			d++;
+ 		}


### PR DESCRIPTION
Critical for proper Unicode support on the filesystem - see:
https://dev.openwrt.org/ticket/7993
https://dev.openwrt.org/changeset/43084
https://dev.openwrt.org/changeset/43085/

This appears to work with no changes required.