### PR TITLE
MR3020(UN) Support

### DIFF
--- a/target/linux/generic/patches-3.3/091-mtd-backport-GD25Q32-GD25Q64.patch
+++ b/target/linux/generic/patches-3.3/091-mtd-backport-GD25Q32-GD25Q64.patch
@@ -1,0 +1,13 @@
+--- a/drivers/mtd/devices/m25p80.c
++++ b/drivers/mtd/devices/m25p80.c
+@@ -707,6 +707,10 @@ static const struct spi_device_id m25p_i
+ 	{ "en25p64", INFO(0x1c2017, 0, 64 * 1024, 128, 0) },
+ 	{ "en25q64", INFO(0x1c3017, 0, 64 * 1024, 128, SECT_4K) },
+ 
++	/* GigaDevice */
++	{ "gd25q32", INFO(0xc84016, 0, 64 * 1024, 64, SECT_4K) },
++	{ "gd25q64", INFO(0xc84017, 0, 64 * 1024, 128, SECT_4K) },
++
+ 	/* Intel/Numonyx -- xxxs33b */
+ 	{ "160s33b",  INFO(0x898911, 0, 64 * 1024,  32, 0) },
+ 	{ "320s33b",  INFO(0x898912, 0, 64 * 1024,  64, 0) },


### PR DESCRIPTION
Backport of GigaDevice GD25Q32/GD25Q64 SPI Flash Support

author  Michel Stempin <michel.stempin@wanadoo.fr>      2013-01-06 00:39:36 +0100
committer       Artem Bityutskiy <artem.bityutskiy@linux.intel.com>     2013-02-04 09:26:29 +0200
commit  55bf75b7dd8ec875d048824f3cdecf8254e292e5 (patch)
tree    e453aa5f14661c3c033576d81f1f07f5f3ea209d /drivers/mtd/devices/m25p80.c
parent  62116e5171e00f85a8d53f76e45b84423c89ff34 (diff)
download        linux-55bf75b7dd8ec875d048824f3cdecf8254e292e5.tar.gz
mtd: chips: Add support for GigaDevice GD25Q32/GD25Q64 SPI Flash in m25p80.c
Add support for GigaDevice GD25Q32 32 Mbit (4 MB) SPI Flash (see datasheet:
http://www.gigadevice.com/UserFiles/GD25Q32_Rev0.2(1).pdf) used in Hame MPR-A1
and clones, and for GigaDevice GD25Q64 64 Mbit (8 MB) SPI Flash used in
Hame MPR-A2 devices (datasheet: http://www.gigadevice.com/UserFiles/GD25Q64.pdf).

Signed-off-by: Michel Stempin <michel.stempin@wanadoo.fr>
Signed-off-by: Artem Bityutskiy <artem.bityutskiy@linux.intel.com>
---